### PR TITLE
feat: Adicionar estrutura da classe GlobalExceptionHandler e implementar o manipulador MethodArgumentNotValidException

### DIFF
--- a/event_service/src/main/java/com/azvtech/event_service/exception/ErrorResponse.java
+++ b/event_service/src/main/java/com/azvtech/event_service/exception/ErrorResponse.java
@@ -1,0 +1,27 @@
+package com.azvtech.event_service.exception;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+/**
+ * @author Fellipe Toledo
+ */
+@Getter
+@Setter
+public class ErrorResponse {
+
+    private int status;
+    private String message;
+    private Map<String, String> errors;
+    private LocalDateTime timestamp;
+
+    public ErrorResponse(int status, String message, Map<String, String> errors) {
+        this.status = status;
+        this.message = message;
+        this.errors = errors;
+        this.timestamp = LocalDateTime.now();
+    }
+}

--- a/event_service/src/main/java/com/azvtech/event_service/exception/GlobalExceptionHandler.java
+++ b/event_service/src/main/java/com/azvtech/event_service/exception/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package com.azvtech.event_service.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Fellipe Toledo
+ */
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+
+        ex.getBindingResult().getFieldErrors().forEach(error -> {
+            String fieldName = error.getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "Validation failed",
+                errors
+        );
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+}


### PR DESCRIPTION
## Alterações propostas
Este PR implementa um manipulador de exceção global para padronizar a forma como os erros de validação são tratados em todo o aplicativo.

## Detalhes da implementação
- Adicionada a classe GlobalExceptionHandler com @RestControllerAdvice
- Implementação do formato personalizado de resposta a erros
- Adicionado tratamento abrangente para MethodArgumentNotValidException

## Testes realizados
- Teste manual com solicitações inválidas
- Formato de resposta de erro verificado

## Respostas de erro
```
{
    "status": 400,
    "message": "Validation failed",
    "timestamp": "2024-01-20T10:15:30.123",
    "errors": {
        "regulationDate": "Regulation date cannot be null",
        "description": "Description cannot be blank",
        "neighborhood": "Neighborhood cannot be null",
        "regulationNumber": "Regulation Number cannot be null",
        "roadblocks": "Roadblocks cannot be null"
    }
}
```

## Problema relacionado
Closes #[76]

## Lista de verificação
- [x] O código segue as diretrizes de estilo do projeto
- [x] Documentação atualizada
- [x] Não foram introduzidos novos avisos
- [x] Cenários de erro testados